### PR TITLE
addding the rendered book to the .gitignore so it's not automatically tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,3 +274,9 @@ TSWLatexianTemp*
 
 # Makeindex log files
 *.lpz
+
+## Rendered book
+
+_book/
+_main.pdf
+


### PR DESCRIPTION
I added `_book/` and `_main.pdf` to the `.gitignore` file. Without this, the rendered book is not ignored by git and shows up as "Untracked files."

My guess is that the rendered book is not something you want to track in the repo itself. With the gitignore set up as-is, it's easy to accidentally add those files to the repo by a contributor if not careful.

@bob-carpenter, feel free to close this PR if it was the intended behavior.

